### PR TITLE
fix: resolve React import warnings (PR 2/7)

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, RefreshCw, Home, Mail } from 'lucide-react';
 
@@ -10,7 +10,7 @@ interface GlobalErrorProps {
 }
 
 export default function GlobalError({ error, reset }: GlobalErrorProps) {
-  React.useEffect(() => {
+  useEffect(() => {
     // Log global errors
     console.error('Global Error:', error);
     

--- a/components/artifact-with-error-boundary.tsx
+++ b/components/artifact-with-error-boundary.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect, useCallback, ErrorInfo } from 'react';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { ArtifactErrorFallback, LoadingErrorFallback } from '@/components/error-fallbacks';
 import { Artifact } from './artifact';
@@ -30,7 +30,7 @@ interface ArtifactWithErrorBoundaryProps {
 }
 
 export function ArtifactWithErrorBoundary(props: ArtifactWithErrorBoundaryProps) {
-  const handleArtifactError = React.useCallback((error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleArtifactError = useCallback((error: Error, errorInfo: ErrorInfo, errorId: string) => {
     logError(error, errorInfo, {
       component: 'Artifact',
       chatId: props.chatId,
@@ -64,7 +64,7 @@ export function ArtifactContentErrorBoundary({
   artifactType: string;
   documentId?: string;
 }) {
-  const handleContentError = React.useCallback((error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleContentError = useCallback((error: Error, errorInfo: ErrorInfo, errorId: string) => {
     logError(error, errorInfo, {
       component: 'ArtifactContent',
       artifactType,
@@ -138,7 +138,7 @@ export function DocumentLoadingErrorBoundary({
   children: React.ReactNode;
   documentId?: string;
 }) {
-  const handleDocumentError = React.useCallback(async (error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleDocumentError = useCallback(async (error: Error, errorInfo: ErrorInfo, errorId: string) => {
     // Enhanced error handling for document loading
     await logError(error, errorInfo, {
       component: 'DocumentLoading',
@@ -182,16 +182,16 @@ export function ArtifactEditorErrorBoundary({
   documentId?: string;
   content?: string;
 }) {
-  const [lastGoodContent, setLastGoodContent] = React.useState<string>('');
+  const [lastGoodContent, setLastGoodContent] = useState<string>('');
 
   // Track last known good content
-  React.useEffect(() => {
+  useEffect(() => {
     if (content && content !== lastGoodContent) {
       setLastGoodContent(content);
     }
   }, [content, lastGoodContent]);
 
-  const handleEditorError = React.useCallback(async (error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleEditorError = useCallback(async (error: Error, errorInfo: ErrorInfo, errorId: string) => {
     await logError(error, errorInfo, {
       component: 'ArtifactEditor',
       documentId,

--- a/components/auth-with-error-boundary.tsx
+++ b/components/auth-with-error-boundary.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useCallback, Children, isValidElement, cloneElement, ReactElement, ErrorInfo } from 'react';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { AuthErrorFallback, NetworkErrorFallback } from '@/components/error-fallbacks';
 import { AuthForm } from './auth-form';
@@ -21,7 +21,7 @@ export function AuthWithErrorBoundary({
   defaultEmail = '',
   formType = 'login',
 }: AuthWithErrorBoundaryProps) {
-  const handleAuthError = React.useCallback((error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleAuthError = useCallback((error: Error, errorInfo: ErrorInfo, errorId: string) => {
     logError(error, errorInfo, {
       component: 'AuthForm',
       formType,
@@ -53,10 +53,10 @@ export function EnhancedAuthForm({
   defaultEmail = '',
   formType = 'login',
 }: AuthWithErrorBoundaryProps) {
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = React.useCallback(async (formData: FormData) => {
+  const handleSubmit = useCallback(async (formData: FormData) => {
     setIsLoading(true);
     setError(null);
 
@@ -133,9 +133,9 @@ export function EnhancedAuthForm({
         <AuthFormFields defaultEmail={defaultEmail} />
         
         <div className="flex flex-col gap-2">
-          {React.Children.map(children, child => {
-            if (React.isValidElement(child) && child.type === 'button') {
-              return React.cloneElement(child as React.ReactElement<any>, {
+          {Children.map(children, child => {
+            if (isValidElement(child) && child.type === 'button') {
+              return cloneElement(child as ReactElement<any>, {
                 disabled: isLoading,
                 children: isLoading ? 'Please wait...' : child.props.children,
               });
@@ -238,7 +238,7 @@ function PasswordField() {
 
 // Session error boundary
 export function SessionErrorBoundary({ children }: { children: React.ReactNode }) {
-  const handleSessionError = React.useCallback((error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleSessionError = useCallback((error: Error, errorInfo: ErrorInfo, errorId: string) => {
     logError(error, errorInfo, {
       component: 'Session',
       errorType: 'session_error',
@@ -283,7 +283,7 @@ export function SessionErrorBoundary({ children }: { children: React.ReactNode }
 
 // Auth provider error boundary
 export function AuthProviderErrorBoundary({ children }: { children: React.ReactNode }) {
-  const handleProviderError = React.useCallback((error: Error, errorInfo: React.ErrorInfo, errorId: string) => {
+  const handleProviderError = useCallback((error: Error, errorInfo: ErrorInfo, errorId: string) => {
     logError(error, errorInfo, {
       component: 'AuthProvider',
       errorType: 'auth_provider_error',

--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { MessageInput } from './MessageInput';
 import { SessionTabs } from '../session/SessionTabs';
@@ -41,17 +41,17 @@ export function ChatInterface({
     loadExternalSession,
   } = useChatStore();
 
-  const [isUserScrolling, setIsUserScrolling] = React.useState(false);
-  const [autoScrollEnabled, setAutoScrollEnabled] = React.useState(true);
-  const messagesEndRef = React.useRef<HTMLDivElement>(null);
-  const messagesContainerRef = React.useRef<HTMLDivElement>(null);
-  const scrollTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const [isUserScrolling, setIsUserScrolling] = useState(false);
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const activeSession = getActiveSession();
   const sessionList = Array.from(sessions.values());
 
   // Sistema inteligente de auto-scroll
-  const scrollToBottom = React.useCallback((behavior: ScrollBehavior = "smooth") => {
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     if (!autoScrollEnabled || isUserScrolling) return;
     
     requestAnimationFrame(() => {
@@ -64,7 +64,7 @@ export function ChatInterface({
   }, [autoScrollEnabled, isUserScrolling]);
 
   // Detecta quando usuário está rolando manualmente
-  const handleScroll = React.useCallback(() => {
+  const handleScroll = useCallback(() => {
     if (!messagesContainerRef.current) return;
     
     const container = messagesContainerRef.current;
@@ -89,7 +89,7 @@ export function ChatInterface({
   }, []);
 
   // Auto-scroll quando houver novas mensagens
-  React.useEffect(() => {
+  useEffect(() => {
     if (autoScrollEnabled && !isUserScrolling) {
       const timeoutId = setTimeout(() => {
         scrollToBottom("smooth");
@@ -100,7 +100,7 @@ export function ChatInterface({
   }, [activeSession?.messages, streamingContent, scrollToBottom, autoScrollEnabled, isUserScrolling]);
 
   // Força scroll quando iniciar streaming
-  React.useEffect(() => {
+  useEffect(() => {
     if (isStreaming) {
       setAutoScrollEnabled(true);
       setIsUserScrolling(false);
@@ -109,14 +109,14 @@ export function ChatInterface({
   }, [isStreaming, scrollToBottom]);
 
   // Carregar sessão externa
-  React.useEffect(() => {
+  useEffect(() => {
     if (sessionData && sessionData.messages) {
       loadExternalSession(sessionData);
     }
   }, [sessionData, loadExternalSession]);
 
   // Carregar histórico de demonstração na primeira vez
-  React.useEffect(() => {
+  useEffect(() => {
     // Converter Map para array
     const sessionList = sessions instanceof Map ? Array.from(sessions.values()) : 
                        Array.isArray(sessions) ? sessions : [];


### PR DESCRIPTION
## 🎯 Atomic PR 2/7: React Import Warnings

### Summary
- Fixes ~30 React import warnings from eslint/import plugin
- Converts default imports to named imports for React hooks and utilities

### Changes
- `React.useCallback` → `useCallback`
- `React.useState` → `useState`
- `React.useEffect` → `useEffect`
- `React.Children` → `Children`
- `React.isValidElement` → `isValidElement`
- `React.cloneElement` → `cloneElement`

### Files Modified
- `app/global-error.tsx`
- `components/artifact-with-error-boundary.tsx`
- `components/auth-with-error-boundary.tsx`
- `components/chat/ChatInterface.tsx`

### Benefits
✅ Eliminates eslint warnings about named exports
✅ More idiomatic React code
✅ Better tree-shaking potential
✅ Consistent import style across codebase

### Testing
- [ ] TypeScript builds successfully  
- [ ] No new lint errors
- [ ] Components render correctly

Part of splitting #7 into atomic PRs