### PR TITLE
fix: use Tailwind shorthand classes (PR 3/7)

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -39,7 +39,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
         <div className="min-h-screen flex items-center justify-center bg-background px-4">
           <div className="max-w-md w-full text-center">
             <div className="flex justify-center mb-6">
-              <AlertTriangle className="w-16 h-16 text-red-500" />
+              <AlertTriangle className="size-16 text-red-500" />
             </div>
             
             <h1 className="text-2xl font-bold text-foreground mb-4">
@@ -68,7 +68,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button onClick={reset} className="flex items-center gap-2">
-                <RefreshCw className="w-4 h-4" />
+                <RefreshCw className="size-4" />
                 Try Again
               </Button>
               
@@ -77,7 +77,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
                 onClick={() => window.location.href = '/'}
                 className="flex items-center gap-2"
               >
-                <Home className="w-4 h-4" />
+                <Home className="size-4" />
                 Go Home
               </Button>
               
@@ -86,7 +86,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
                 onClick={() => window.location.href = 'mailto:support@example.com'}
                 className="flex items-center gap-2"
               >
-                <Mail className="w-4 h-4" />
+                <Mail className="size-4" />
                 Contact Support
               </Button>
             </div>

--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -358,7 +358,7 @@ export function ChatInterface({
               href="/"
               className="flex items-center gap-3 hover:opacity-80 transition-opacity"
             >
-              <Bot className="h-6 w-6 text-primary" />
+              <Bot className="size-6 text-primary" />
               <div className="flex flex-col">
                 <h1 className="text-xl font-semibold">Claude Chat</h1>
               </div>
@@ -378,7 +378,7 @@ export function ChatInterface({
               disabled={!activeSession}
               title="Exportar sessão"
             >
-              <Download className="h-5 w-5" />
+              <Download className="size-5" />
             </Button>
 
             {!readOnly && (
@@ -388,7 +388,7 @@ export function ChatInterface({
                 onClick={() => window.location.reload()}
                 title="Atualizar página"
               >
-                <RefreshCw className="h-5 w-5" />
+                <RefreshCw className="size-5" />
               </Button>
             )}
 
@@ -398,7 +398,7 @@ export function ChatInterface({
               onClick={() => console.log("Configurações em desenvolvimento")}
               title="Configurações"
             >
-              <Settings className="h-5 w-5" />
+              <Settings className="size-5" />
             </Button>
           </div>
         </div>
@@ -426,7 +426,7 @@ export function ChatInterface({
               <div className="mx-auto max-w-4xl">
                 {activeSession?.messages.length === 0 && !isStreaming && (
                   <Card className="p-8 text-center">
-                    <Bot className="mx-auto h-12 w-12 text-muted-foreground" />
+                    <Bot className="mx-auto size-12 text-muted-foreground" />
                     <h2 className="mt-4 text-lg font-medium">
                       Comece uma conversa
                     </h2>
@@ -450,8 +450,8 @@ export function ChatInterface({
                 {isProcessing && !streamingContent && (
                   <div className="flex items-center justify-start mb-6">
                     <div className="flex gap-3">
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted">
-                        <Bot className="h-5 w-5" />
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted">
+                        <Bot className="size-5" />
                       </div>
                       <div className="text-sm text-muted-foreground">
                         Processando resposta...
@@ -483,7 +483,7 @@ export function ChatInterface({
                       className="rounded-full shadow-lg"
                       title="Voltar ao final"
                     >
-                      <ArrowDown className="h-5 w-5" />
+                      <ArrowDown className="size-5" />
                     </Button>
                   </div>
                 )}
@@ -511,7 +511,7 @@ export function ChatInterface({
               <div className="mx-auto flex max-w-4xl items-center justify-between text-xs text-muted-foreground">
                 <div className="flex items-center gap-4">
                   <span className="flex items-center gap-1">
-                    <Activity className="h-3 w-3" />
+                    <Activity className="size-3" />
                     {activeSession.messages.length} mensagens
                   </span>
                   <span className="flex items-center gap-1">


### PR DESCRIPTION
## 🎯 Atomic PR 3/7: Tailwind Shorthand Classes

### Summary
- Replaces verbose width/height classes with Tailwind shorthand
- Fixes tailwindcss/enforces-shorthand warnings

### Changes
- `h-X w-X` → `size-X` (for equal width and height)
- More concise and maintainable CSS classes

### Files Modified
- `app/global-error.tsx` (4 changes)
- `components/chat/ChatInterface.tsx` (10 changes)

### Benefits
✅ Eliminates 14 Tailwind shorthand warnings
✅ Cleaner, more concise class names
✅ Better adherence to Tailwind best practices
✅ Smaller HTML output

### Testing
- [ ] UI renders correctly with new classes
- [ ] No visual regressions
- [ ] Tailwind warnings resolved

Part of splitting #7 into atomic PRs