### PR TITLE
fix: add missing htmlFor attributes to labels (PR 5/7)

### DIFF
--- a/app/test-claude/page.tsx
+++ b/app/test-claude/page.tsx
@@ -71,10 +71,11 @@ export default function TestClaude() {
       
       <div className="max-w-2xl space-y-4">
         <div>
-          <label className="block text-sm font-medium mb-2">
+          <label htmlFor="test-message" className="block text-sm font-medium mb-2">
             Mensagem de teste:
           </label>
           <input
+            id="test-message"
             type="text"
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/components/claude-chat.tsx
+++ b/components/claude-chat.tsx
@@ -192,11 +192,13 @@ export function ClaudeChat({ sessionId: initialSessionId }: ClaudeChatProps = {}
           
           {/* Slider de Velocidade Personalizado */}
           <div className="speed-control">
+            <label htmlFor="speed-slider" className="sr-only">Velocidade de streaming</label>
             <span className={`text-sm ${isMounted && streamSpeed > 100 ? 'speed-emoji-slow' : ''}`}>
               🐢
             </span>
             <div className="relative">
               <input
+                id="speed-slider"
                 type="range"
                 min="10"
                 max="200"
@@ -317,8 +319,10 @@ export function ClaudeChat({ sessionId: initialSessionId }: ClaudeChatProps = {}
       </div>
 
       <form onSubmit={handleSubmit} className="p-4 border-t">
+        <label htmlFor="message-input" className="sr-only">Digite sua mensagem</label>
         <div className="flex space-x-2">
           <input
+            id="message-input"
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}


### PR DESCRIPTION
## 🎯 Atomic PR 5/7: Label htmlFor Attributes

### Summary
- Adds missing `htmlFor` attributes to label elements
- Ensures proper label-input association for accessibility
- Adds screen-reader only labels for inputs without visible labels

### Changes
- Added `htmlFor` and `id` attributes to form elements
- Added `sr-only` labels for range slider and message input
- Improves keyboard navigation and screen reader support

### Files Modified
- `app/test-claude/page.tsx` (1 label/input pair)
- `components/claude-chat.tsx` (2 inputs with sr-only labels)

### Benefits
✅ Better accessibility compliance (WCAG 2.1)
✅ Improved screen reader support
✅ Clickable labels activate associated inputs
✅ Better form semantics

### Testing
- [ ] Labels are properly associated with inputs
- [ ] Clicking labels focuses the input
- [ ] Screen readers announce labels correctly

Part of splitting #7 into atomic PRs