### PR TITLE
fix: wrap window.location assignments in blocks (PR 6/7)

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -74,7 +74,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
               
               <Button 
                 variant="outline" 
-                onClick={() => window.location.href = '/'}
+                onClick={() => { window.location.href = '/'; }}
                 className="flex items-center gap-2"
               >
                 <Home className="w-4 h-4" />
@@ -83,7 +83,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
               
               <Button 
                 variant="ghost" 
-                onClick={() => window.location.href = 'mailto:support@example.com'}
+                onClick={() => { window.location.href = 'mailto:support@example.com'; }}
                 className="flex items-center gap-2"
               >
                 <Mail className="w-4 h-4" />

--- a/components/auth-with-error-boundary.tsx
+++ b/components/auth-with-error-boundary.tsx
@@ -263,7 +263,7 @@ export function SessionErrorBoundary({ children }: { children: React.ReactNode }
                 Retry
               </button>
               <button
-                onClick={() => window.location.href = '/login'}
+                onClick={() => { window.location.href = '/login'; }}
                 className="px-3 py-1 bg-gray-600 text-white rounded text-sm hover:bg-gray-700"
               >
                 Sign In

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -153,7 +153,7 @@ const DefaultErrorFallback: React.FC<ErrorFallbackProps> = ({
           )}
           
           <Button
-            onClick={() => window.location.href = '/'}
+            onClick={() => { window.location.href = '/'; }}
             variant="outline"
             className="flex items-center gap-2"
           >

--- a/components/error-fallbacks.tsx
+++ b/components/error-fallbacks.tsx
@@ -97,7 +97,7 @@ export const ChatErrorFallback: React.FC<ErrorFallbackProps> = ({
         
         {errorType === 'auth' && (
           <Button
-            onClick={() => window.location.href = '/login'}
+            onClick={() => { window.location.href = '/login'; }}
             variant="outline"
             className="flex-1"
           >
@@ -267,7 +267,7 @@ export const AuthErrorFallback: React.FC<ErrorFallbackProps> = ({
         
         <Button
           variant="outline"
-          onClick={() => window.location.href = '/'}
+          onClick={() => { window.location.href = '/'; }}
           className="flex items-center gap-2"
         >
           <Home className="w-4 h-4" />


### PR DESCRIPTION
## 🎯 Atomic PR 6/7: Window Location Assignments

### Summary
- Wraps `window.location.href` assignments in block statements
- Prevents lint warnings about assignments in expressions
- Follows JavaScript/TypeScript best practices

### Changes
- Changed `() => window.location.href = '/'` to `() => { window.location.href = '/'; }`
- Ensures assignments are statements, not expressions

### Files Modified
- `app/global-error.tsx` (2 changes)
- `components/error-fallbacks.tsx` (2 changes)
- `components/auth-with-error-boundary.tsx` (1 change)
- `components/error-boundary.tsx` (1 change)

### Benefits
✅ Eliminates lint warnings about assignments in expressions
✅ More explicit intent in code
✅ Better code clarity
✅ Follows ESLint best practices

### Testing
- [ ] Navigation still works correctly
- [ ] No JavaScript errors in console
- [ ] Redirects function as expected

Part of splitting #7 into atomic PRs